### PR TITLE
Add defaults to manifest

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -122,6 +122,11 @@ func create(_ *cobra.Command, args []string) {
 		logrus.Fatal("invalid variables: ", err)
 	}
 
+	err = pkg.ApplyDefaultVars(corr.Vars)
+	if err != nil {
+		logrus.Fatal("invalid defaults: ", err)
+	}
+
 	logrus.Info("generating ssh keys")
 	privkey, _ := generatePrivateKey(2048)
 	pubkey, _ := generatePublicKey(&privkey.PublicKey)

--- a/cmd/package/validate.go
+++ b/cmd/package/validate.go
@@ -33,7 +33,12 @@ func validate(_ *cobra.Command, args []string) {
 		logrus.Fatal("Terraform module not found.")
 	}
 
-	_, err := _package.LoadPackage(args[0])
+	pkg, err := _package.LoadPackage(args[0])
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	err = pkg.ValidateDefaults()
 	if err != nil {
 		logrus.Fatal(err)
 	}

--- a/packages/k3s-ha/manifest.yaml
+++ b/packages/k3s-ha/manifest.yaml
@@ -33,19 +33,23 @@ variables:
     optional: true
     description: "How many control-plane nodes should be created."
     minimum: 1
+    default: 3
   controlplane_size:
       type: string
       optional: true
       description: "What size droplet to use for control-plane nodes. https://slugs.do-api.dev/"
+      default: "s-1vcpu-2gb"
   agent_count:
     type: integer
     optional: true
     minimum: 1
     description: "How many agent nodes should be created."
+    default: 1
   agent_size:
     type: string
     optional: true
     description: "What size droplet to use for agent nodes. https://slugs.do-api.dev/"
+    default: "s-1vcpu-2gb"
   kube_api_host:
     type: string
     readOnly: true

--- a/packages/k3s-ha/terraform/module/agent.tf
+++ b/packages/k3s-ha/terraform/module/agent.tf
@@ -1,9 +1,7 @@
 variable "agent_count" {
   type = number
-  default = 1
 }
 variable "agent_size" {
-  default = "s-1vcpu-2gb"
 }
 
 resource "digitalocean_droplet" "agent" {

--- a/packages/k3s-ha/terraform/module/controlplane.tf
+++ b/packages/k3s-ha/terraform/module/controlplane.tf
@@ -1,9 +1,7 @@
 variable "controlplane_count" {
   type = number
-  default = 3
 }
 variable "controlplane_size" {
-  default = "s-1vcpu-2gb"
 }
 
 resource "digitalocean_droplet" "controlplane" {

--- a/packages/k3s/manifest.yaml
+++ b/packages/k3s/manifest.yaml
@@ -23,6 +23,7 @@ variables:
       type: string
       optional: true
       description: "What size droplet to use for the node nodes. https://slugs.do-api.dev/"
+      default: "s-1vcpu-2gb"
   kube_api_host:
     type: string
     readOnly: true

--- a/packages/k3s/terraform/module/controlplane.tf
+++ b/packages/k3s/terraform/module/controlplane.tf
@@ -1,5 +1,4 @@
 variable "node_size" {
-  default = "s-1vcpu-2gb"
 }
 
 resource "digitalocean_droplet" "controlplane" {

--- a/packages/rancher-ha/terraform/module/corral.tf
+++ b/packages/rancher-ha/terraform/module/corral.tf
@@ -4,7 +4,6 @@ variable "corral_user_public_key" {}
 variable "corral_public_key" {}
 
 variable "rancher_version" {
-  default = ""
 }
 
 output "corral_node_pools" {

--- a/packages/rancher/terraform/module/corral.tf
+++ b/packages/rancher/terraform/module/corral.tf
@@ -5,7 +5,6 @@ variable "corral_public_key" {}
 
 // tf errors when unexpected variables are passed
 variable "rancher_version" {
-  default = ""
 }
 
 output "corral_node_pools" {

--- a/packages/rke2-ha/manifest.yaml
+++ b/packages/rke2-ha/manifest.yaml
@@ -33,19 +33,23 @@ variables:
     optional: true
     description: "How many control-plane nodes should be created."
     minimum: 1
+    default: 3
   controlplane_size:
     type: string
     optional: true
     description: "What size droplet to use for control-plane nodes. https://slugs.do-api.dev/"
+    default: "s-2vcpu-4gb"
   agent_count:
     type: integer
     optional: true
     minimum: 1
     description: "How many agent nodes should be created."
+    default: 1
   agent_size:
     type: string
     optional: true
     description: "What size droplet to use for agent nodes. https://slugs.do-api.dev/"
+    default: "s-2vcpu-4gb"
   kube_api_host:
     type: string
     readOnly: true

--- a/packages/rke2-ha/terraform/module/agent.tf
+++ b/packages/rke2-ha/terraform/module/agent.tf
@@ -1,9 +1,7 @@
 variable "agent_count" {
   type = number
-  default = 1
 }
 variable "agent_size" {
-  default = "s-2vcpu-4gb"
 }
 
 resource "digitalocean_droplet" "agent" {

--- a/packages/rke2-ha/terraform/module/controlplane.tf
+++ b/packages/rke2-ha/terraform/module/controlplane.tf
@@ -1,9 +1,7 @@
 variable "controlplane_count" {
   type = number
-  default = 3
 }
 variable "controlplane_size" {
-  default = "s-2vcpu-4gb"
 }
 
 resource "digitalocean_droplet" "controlplane" {

--- a/packages/rke2/manifest.yaml
+++ b/packages/rke2/manifest.yaml
@@ -24,6 +24,7 @@ variables:
     type: string
     optional: true
     description: "What size droplet to use for nodes. https://slugs.do-api.dev/"
+    default: "s-2vcpu-4gb"
   kube_api_host:
     type: string
     readOnly: true

--- a/packages/rke2/terraform/module/controlplane.tf
+++ b/packages/rke2/terraform/module/controlplane.tf
@@ -1,5 +1,4 @@
 variable "node_size" {
-  default = "s-2vcpu-4gb"
 }
 
 resource "digitalocean_droplet" "controlplane" {

--- a/pkg/package/manifest_test.go
+++ b/pkg/package/manifest_test.go
@@ -30,7 +30,7 @@ func TestLoadManifest(t *testing.T) {
 		assert.Len(t, res.Commands[0].NodePoolNames, 1)
 		assert.Equal(t, "foo", res.Commands[0].NodePoolNames[0])
 
-		assert.Len(t, res.VariableSchemas, 4)
+		assert.Len(t, res.VariableSchemas, 5)
 
 		assert.NotNil(t, res.VariableSchemas["a"])
 		assert.False(t, res.VariableSchemas["a"].Sensitive)
@@ -135,11 +135,12 @@ func TestFilterVars(t *testing.T) {
 		"c": "",
 		"d": "",
 		"e": "",
+		"f": "",
 	}
 
 	res := manifest.FilterVars(vars)
 
-	assert.Equal(t, res, _package.VarSet{"a": "", "b": "", "c": "", "d": ""})
+	assert.Equal(t, res, _package.VarSet{"a": "", "b": "", "c": "", "d": "", "e": ""})
 }
 
 func TestFilterSensitiveVars(t *testing.T) {

--- a/pkg/package/package-manifest.schema.json
+++ b/pkg/package/package-manifest.schema.json
@@ -69,6 +69,10 @@
           "type": "boolean",
           "default": true,
           "description": "If a variable is marked as read only it can only returned by a corral, not set."
+        },
+        "default": {
+          "type": "object",
+          "description": "If a variable has a default value and a value is not present for that variable, the default value will be used instead."
         }
       }
     }

--- a/pkg/package/tests/valid.yaml
+++ b/pkg/package/tests/valid.yaml
@@ -19,3 +19,6 @@ variables:
   d:
     type: boolean
     optional: true
+  e:
+    type: string
+    default: test

--- a/pkg/package/variable.go
+++ b/pkg/package/variable.go
@@ -12,4 +12,5 @@ type Schema struct {
 	Sensitive   bool
 	Optional    bool
 	Description string
+	Default     string
 }


### PR DESCRIPTION
#14 
Defaults can be any type in the manifest, but are stored as strings in the `corral.yaml`. Terraform doesn't seem to have an issue with this for primitive data types, so this shouldn't be an issue. Also updated each package manifest, validated all and tested ~half (rke2 and k3s are identical, seems redundant to do both).