### PR TITLE
added option to skip cleanup when deleting a corral

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -26,13 +26,12 @@ func NewCommandDelete() *cobra.Command {
 		Run:   deleteCorral,
 	}
 
-	cmd.Flags().Bool("dry-run", false, "Display what resources this corral will create.")
-	_ = cfgViper.BindPFlag("dry-run", cmd.Flags().Lookup("dry-run"))
+	cmd.Flags().Bool("skip-cleanup", false, "Do not run terraform destroy just delete the package.  This can result in un-tracked infrastructure resources!")
 
 	return cmd
 }
 
-func deleteCorral(_ *cobra.Command, args []string) {
+func deleteCorral(cmd *cobra.Command, args []string) {
 	for _, name := range args {
 		c, err := corral.Load(config.CorralPath(name))
 		if err != nil {
@@ -46,24 +45,26 @@ func deleteCorral(_ *cobra.Command, args []string) {
 
 		c.SetStatus(corral.StatusDeleting)
 
-		logrus.Infof("running terraform destroy for [%s]", name)
-		pkg, err := _package.LoadPackage(c.Source)
-		if err != nil {
-			logrus.Error("could not load package associated with corral: ", err)
-		}
+		if skip, _ := cmd.Flags().GetBool("skip-cleanup"); !skip {
+			logrus.Infof("running terraform destroy for [%s]", name)
+			pkg, err := _package.LoadPackage(c.Source)
+			if err != nil {
+				logrus.Error("could not load package associated with corral: ", err)
+			}
 
-		tf, err := config.NewTerraform(c.TerraformPath(), pkg.TerraformVersion())
-		if err != nil {
-			logrus.Fatal("failed to load terraform: ", err)
-		}
-		if debug {
-			tf.SetStdout(os.Stdout)
-		}
+			tf, err := config.NewTerraform(c.TerraformPath(), pkg.TerraformVersion())
+			if err != nil {
+				logrus.Fatal("failed to load terraform: ", err)
+			}
+			if debug {
+				tf.SetStdout(os.Stdout)
+			}
 
-		err = tf.Destroy(context.Background())
-		if err != nil {
-			logrus.Errorf("failed to cleanup corral resources [%s]: %s", c.Name, err)
-			continue
+			err = tf.Destroy(context.Background())
+			if err != nil {
+				logrus.Errorf("failed to cleanup corral resources [%s]: %s", c.Name, err)
+				continue
+			}
 		}
 
 		err = c.Delete()


### PR DESCRIPTION
closes #39 

# Problem
If a corral is created with a var that results in invalid terraform there is no way to delete it.

# Solution
Added a flag to delete that skips running terraform destroy.  In most cases when users are in this state no resources were created anyway.