### PR TITLE
Shells will not check a commands exit code and return an error if the…

### DIFF
--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -57,7 +57,7 @@ func deleteCorral(cmd *cobra.Command, args []string) {
 						continue
 					}
 
-					logrus.Infof("destroying module: %s", pkg.Commands[i].Module)
+					logrus.Debugf("destroying module: %s", pkg.Commands[i].Module)
 					if err = c.DestroyModule(pkg.Commands[i].Module); err != nil {
 						logrus.Errorf("failed to cleanup module [%s]: %v", pkg.Commands[i].Module, err)
 						continue

--- a/pkg/shell/registry.go
+++ b/pkg/shell/registry.go
@@ -1,0 +1,62 @@
+package shell
+
+import (
+	"github.com/rancherlabs/corral/pkg/corral"
+	"github.com/rancherlabs/corral/pkg/vars"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sync"
+	"time"
+)
+
+type Registry struct {
+	reg *sync.Map
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		reg: &sync.Map{},
+	}
+}
+
+// GetShell will return the shell associated with the given node's address.  If the shell does not exist one will be
+// created.
+func (r *Registry) GetShell(n corral.Node, privateKey string, vs vars.VarSet) (*Shell, error) {
+	var err error
+
+	if sh, ok := r.reg.Load(n.Address); ok {
+		return sh.(*Shell), nil
+	}
+
+	err = wait.Poll(time.Second, 2*time.Minute, func() (done bool, err error) {
+		sh := &Shell{
+			Node:       n,
+			PrivateKey: []byte(privateKey),
+			Vars:       vs,
+		}
+
+		if err = sh.Connect(); err != nil {
+			sh.Close()
+			return false, nil
+		}
+
+		r.reg.Store(n.Address, sh)
+
+		return err == nil, err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	sh, _ := r.reg.Load(n.Address)
+	return sh.(*Shell), err
+}
+
+// Close all shells in the registry.
+func (r *Registry) Close() {
+	r.reg.Range(func(key, value interface{}) bool {
+		value.(*Shell).Close()
+
+		return true
+	})
+}


### PR DESCRIPTION
closes #23 
closes #11 

Command exit codes are now check after a command is run.  I also simplified how commands are run.  We create a separate session for each command run.  This avoids commands being run in unexpected environments.  Additionally, we reuse shells for the duration of the corral create.  This seems to have resolved the high cpu usage issue.  Finally, the concurrency of file copies and commands is limited to the number of cpu on the user's machine.  This prevents corrals failing to create when there is a large number of nodes.