### PR TITLE
fixed bastion address not being used

### DIFF
--- a/pkg/corral/node.go
+++ b/pkg/corral/node.go
@@ -1,9 +1,9 @@
 package corral
 
 type Node struct {
-	Name           string `yaml:"name,omitempty"`
-	User           string `yaml:"user,omitempty"`
-	Address        string `yaml:"address,omitempty"`
-	BastionAddress string `yaml:"bastion_address,omitempty"`
-	OverlayRoot    string `yaml:"overlay_root"`
+	Name           string `json:"name,omitempty" yaml:"name,omitempty"`
+	User           string `json:"user,omitempty" yaml:"user,omitempty"`
+	Address        string `json:"address,omitempty" yaml:"address,omitempty"`
+	BastionAddress string `json:"bastion_address,omitempty" yaml:"bastion_address,omitempty"`
+	OverlayRoot    string `json:"overlay_root" yaml:"overlay_root"`
 }


### PR DESCRIPTION
Terraform output is parsed as json.  Because `BastionAddress` is two words `bastion_address` was being ignored.