### PR TITLE
Bumped max package name to 255 (OCI image repo max)

### DIFF
--- a/pkg/package/package-manifest.schema.json
+++ b/pkg/package/package-manifest.schema.json
@@ -6,7 +6,7 @@
     "name": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 16,
+      "maxLength": 255,
       "description": "The name of the package."
     },
     "annotations": {


### PR DESCRIPTION
Previous max was 16, which was a little too small, however this issue was encountered because `digitalocean-k3s` is 16 characters.