### PR TITLE
add error to log when config fails to read on `corral create`

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -49,7 +49,7 @@ func NewCommandCreate() *cobra.Command {
 				cfgViper.AddConfigPath(cfgFile)
 				err := cfgViper.ReadInConfig()
 				if err != nil {
-					logrus.Fatal("failed to parse config file.")
+					logrus.Fatalf("Error reading config file: %v", err)
 				}
 			}
 		},


### PR DESCRIPTION
addresses: https://github.com/rancherlabs/corral/issues/92